### PR TITLE
Removing rapl_get_cpu_model() redeclaration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ incdir ?= include
 CC ?= gcc
 
 CFLAGS ?= -g -Wall -O2
-CFLAGS += -fPIC
+CFLAGS += -fPIC -Wredundant-decls
 
 LIBS=-lm
 

--- a/rapl.h
+++ b/rapl.h
@@ -106,8 +106,6 @@ void rapl_print_units(struct rapl_units * ru);
 char rapl_get_pkg_power_info(int fd_msr, struct rapl_units * ru, struct rapl_pkg_power_info * pinfo);
 void rapl_print_pkg_power_info(struct rapl_pkg_power_info * pinfo);
 
-int rapl_get_cpu_model();
-
 void rapl_get_raw_power_counters(int fd_msr, struct rapl_units * runits, struct rapl_raw_power_counters * pc);
 void rapl_print_raw_power_counters (int fd_msr, struct rapl_units * runits);
 


### PR DESCRIPTION
This function was being declared twice in rapl.h.
